### PR TITLE
feat: Add 'How to Play' modal

### DIFF
--- a/src/components/game/Game.tsx
+++ b/src/components/game/Game.tsx
@@ -6,6 +6,7 @@ import GameBoard from './GameBoard';
 import StatusDisplay from './StatusDisplay';
 import GameInfo from './GameInfo';
 import HelpModal from './HelpModal';
+import HowToPlayButton from './HowToPlayButton'; // Added import
 import TabContainer from './TabContainer';
 import GameSettingsModal from './GameSettingsModal';
 import { makeAIMove as makeAILogicMove } from '../../lib/gameLogic';
@@ -361,6 +362,8 @@ export default function Game() {
 
         {/* Help Modal */}
         <HelpModal />
+        {/* How to Play Button/Modal */}
+        <HowToPlayButton />
 
         <h1 className="text-3xl font-bold text-center mb-6 relative">
           <span className="bg-clip-text text-transparent bg-gradient-to-r from-blue-400 via-purple-400 to-blue-500 animate-text-shimmer">

--- a/src/components/game/HowToPlayButton.tsx
+++ b/src/components/game/HowToPlayButton.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import { AtSign } from 'lucide-react';
+import HowToPlayModal from './HowToPlayModal';
+
+const HowToPlayButton: React.FC = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const openModal = () => setIsModalOpen(true);
+  const closeModal = () => setIsModalOpen(false);
+
+  return (
+    <>
+      <button
+        onClick={openModal}
+        className="absolute top-2 right-12 p-2 rounded-full bg-gray-800/70 hover:bg-gray-700/70 text-blue-400 hover:text-blue-300 transition-all duration-300 backdrop-blur-sm border border-gray-700/50 hover:border-gray-600/50 shadow-lg hover:shadow-blue-900/20 z-20"
+        aria-label="How to Play"
+      >
+        <AtSign className="w-5 h-5" /> {/* Adjusted size to match HelpCircle */}
+      </button>
+      <HowToPlayModal isOpen={isModalOpen} onClose={closeModal} />
+    </>
+  );
+};
+
+export default HowToPlayButton;

--- a/src/components/game/HowToPlayModal.tsx
+++ b/src/components/game/HowToPlayModal.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { X } from 'lucide-react';
+
+interface HowToPlayModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const HowToPlayModal: React.FC<HowToPlayModalProps> = ({ isOpen, onClose }) => {
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-70 backdrop-blur-sm">
+      <div className="bg-gradient-to-br from-gray-800 to-slate-900 border border-slate-700 rounded-lg shadow-xl text-white w-full max-w-md mx-4">
+        <div className="flex items-center justify-between p-4 border-b border-slate-700">
+          <h2 className="text-xl font-semibold text-blue-400">How to Play</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-blue-400 transition-colors"
+            aria-label="Close modal"
+          >
+            <X size={24} />
+          </button>
+        </div>
+        <div className="p-6 space-y-3 text-gray-300">
+          {/* How to Play Section - Content updated based on HelpModal.tsx */}
+          {/* The main modal header "How to Play" is already present above, so we don't need another h3 here. */}
+          {/* We will directly use the list structure. */}
+          <div className="p-3 bg-gray-800/50 backdrop-blur-sm rounded-lg border border-gray-700/50">
+            <ol className="list-decimal list-inside space-y-2">
+              <li>Select a game mode (Human vs Human, Human vs AI, or AI vs AI).</li>
+              <li>If playing against AI, select a difficulty level (Easy, Medium, or Hard).</li>
+              <li>The game is played on a 3×3 grid.</li>
+              <li>Players take turns placing their symbol (X or O) in empty cells.</li>
+              <li>The first player to get three of their symbols in a row (horizontally, vertically, or diagonally) wins.</li>
+              <li>If all cells are filled and no player has won, the game is a draw.</li>
+              <li>Use the Reset Game button or press 'R' to start a new game.</li>
+            </ol>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default HowToPlayModal;


### PR DESCRIPTION
Implements a 'How to Play' modal accessible via an '@' icon button.

Key changes:
- I created `HowToPlayModal.tsx`: This displays the rules of Tic-Tac-Toe and is styled consistently with your existing modals.
- I created `HowToPlayButton.tsx`: This renders an '@' icon button that toggles the visibility of the HowToPlayModal. It's positioned next to the existing help icon.
- I integrated `HowToPlayButton` into `Game.tsx`.
- I populated the modal with clear "How to Play" instructions sourced from the existing HelpModal.
- I ensured consistent styling, positioning, and accessibility for the new components.
- I confirmed the logical flow for modal interaction and content display through conceptual testing.